### PR TITLE
Fixed UnitOfWork relationship changes callback

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -369,7 +369,7 @@ class UnitOfWork
                         if ($a === $b) {
                             return 0;
                         }
-                        return spl_object_hash($a) < spl_object_hash($b) ? -1 : 1;
+                        return $a < $b ? -1 : 1;
                     };
 
                     $added = array_udiff($value, $currentValue, $compare);


### PR DESCRIPTION
I must not have read the array_udiff documentation very well when I wrote this, I doubt a comparison on spl_object_hash is going to be transitive. It looks like object comparison isn't always transitive either, but I think it should be for entities.