### PR TITLE
Cast $id to int in findOneById

### DIFF
--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -338,7 +338,7 @@ class BaseRepository
 
     public function findOneById($id)
     {
-        $hydrated = $this->findBy('id', $id, true);
+        $hydrated = $this->findBy('id', (int)$id, true);
 
         return isset($hydrated[0]) ? $hydrated[0] : null;
     }


### PR DESCRIPTION
When using Bolt (not sure about http) integers cannot be specified as strings, as they have to be encoded.