### PR TITLE
Look at all relations for possible updates

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -501,7 +501,7 @@ class UnitOfWork
         foreach ($classMetadata->getRelationshipEntities() as $relationshipMetadata) {
             $value = $relationshipMetadata->getValue($entity);
             if (null === $value || ($relationshipMetadata->isCollection() && count($value) === 0)) {
-                return;
+                continue;
             }
             if ($relationshipMetadata->isCollection()) {
                 foreach ($value as $v) {

--- a/tests/UnitOfWorkTest.php
+++ b/tests/UnitOfWorkTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests;
+
+use GraphAware\Neo4j\OGM\EntityManager;
+use GraphAware\Neo4j\OGM\Tests\Integration\Model\Movie;
+
+class UnitOfWorkTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTraverseRelationshipEntities_makeSureAllRelationsAreVisited()
+    {
+        $fooRelationMetadata = $this->getMockBuilder(DummyRelationMetadata::class)
+            ->setMethods(['getValue'])
+            ->getMock();
+        $barRelationMetadata = $this->getMockBuilder(DummyRelationMetadata::class)
+            ->setMethods(['getValue'])
+            ->getMock();
+
+        $fooRelationMetadata->expects($this->once())
+            ->method('getValue')
+            ->willReturn(null);
+        $barRelationMetadata->expects($this->once())
+            ->method('getValue')
+            ->willReturn(null);
+
+        $baseClassMetadata = $this->getMockBuilder(DummyRelationMetadata::class)
+            ->setMethods(['getRelationshipEntities'])
+            ->getMock();
+
+        $baseClassMetadata->expects($this->any())
+            ->method('getRelationshipEntities')
+            ->willReturn([$fooRelationMetadata, $barRelationMetadata]);
+
+        $entityManager = $this->getMockBuilder('GraphAware\Neo4j\OGM\EntityManager')
+            ->disableOriginalConstructor()
+            ->setMethods(['getClassMetadataFor', 'persistRelationshipEntity'])
+            ->getMock();
+
+        $entityManager->expects($this->once())
+            ->method('getClassMetadataFor')
+            ->with($this->equalTo(Movie::class))
+            ->willReturn($baseClassMetadata);
+
+        $unitOfWork = $this->getMockBuilder('GraphAware\Neo4j\OGM\UnitOfWork')
+            ->setConstructorArgs([$entityManager])
+            ->setMethods(['persistRelationshipEntity', 'doPersist'])
+            ->getMock();
+
+        $movie = new Movie();
+        $unitOfWork->traverseRelationshipEntities($movie);
+    }
+}
+
+
+class DummyRelationMetadata {
+    public function getValue()
+    {
+        return null;
+    }
+    public function getRelationshipEntities()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
This is a high priority bugfix. The bug was introduced in [1.0.0-beta20](https://github.com/graphaware/neo4j-php-ogm/commit/491fcbb4cef690732e2ba39ef08cf9e3d2cd9e3f#diff-ffe84599a511ad2c003ae8967ed1b01fR189)

If we have more than one relationship and the first one we check is empty, then no other relations are checked. 