### PR TITLE
Added implementation for EntityManager::contains() and detach()

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -123,25 +123,37 @@ class EntityManager implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function merge($object)
+    public function merge($entity)
     {
-        // TODO: Implement merge() method.
+        if (!is_object($entity)) {
+            throw new \Exception('EntityManager::merge() expects an object');
+        }
+
+        $this->uow->merge($entity);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function detach($object)
+    public function detach($entity)
     {
-        // TODO: Implement detach() method.
+        if (!is_object($entity)) {
+            throw new \Exception('EntityManager::detach() expects an object');
+        }
+
+        $this->uow->detach($entity);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function refresh($object)
+    public function refresh($entity)
     {
-        // TODO: Implement refresh() method.
+        if (!is_object($entity)) {
+            throw new \Exception('EntityManager::refresh() expects an object');
+        }
+
+        $this->uow->refresh($entity);
     }
 
     /**
@@ -166,14 +178,14 @@ class EntityManager implements ObjectManager
 
     public function initializeObject($obj)
     {
-        // @todo
-        return null;
+        $this->uow->initializeObject($obj);
     }
 
-    public function contains($object)
+    public function contains($entity)
     {
-        /* @todo */
-        return true;
+        return $this->uow->isScheduledForCreate($entity)
+        || $this->uow->isManaged($entity)
+        && ! $this->uow->isScheduledForDelete($entity);
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -564,6 +564,16 @@ class UnitOfWork
         $this->manageEntityReference($oid);
     }
 
+    /**
+     * @param object $entity
+     *
+     * @return bool
+     */
+    public function isManaged($entity)
+    {
+        return isset($this->entityIds[spl_object_hash($entity)]);
+    }
+
     public function scheduleDelete($entity)
     {
         $oid = spl_object_hash($entity);
@@ -620,11 +630,75 @@ class UnitOfWork
     }
 
     /**
+     * Merges the state of the given detached entity into this UnitOfWork.
+     *
+     * @param object $entity
+     *
+     * @return object The managed copy of the entity.
+     */
+    public function merge($entity)
+    {
+        // TODO write me
+        trigger_error("Function not implemented.", E_USER_ERROR);
+    }
+
+    /**
+     * Detaches an entity from the persistence management. It's persistence will
+     * no longer be managed by Doctrine.
+     *
+     * @param object $entity The entity to detach.
+     *
+     * @return void
+     */
+    public function detach($entity)
+    {
+        // TODO write me
+        trigger_error("Function not implemented.", E_USER_ERROR);
+    }
+
+    /**
+     * Refreshes the state of the given entity from the database, overwriting
+     * any local, unpersisted changes.
+     *
+     * @param object $entity The entity to refresh.
+     *
+     * @return void
+     */
+    public function refresh($entity)
+    {
+        // TODO write me
+        trigger_error("Function not implemented.", E_USER_ERROR);
+    }
+
+    /**
+     * Helper method to initialize a lazy loading proxy or persistent collection.
+     *
+     * @param object $obj
+     *
+     * @return void
+     */
+    public function initializeObject($obj)
+    {
+        // TODO write me
+        trigger_error("Function not implemented.", E_USER_ERROR);
+    }
+
+    /**
      * @return array
      */
     public function getNodesScheduledForCreate()
     {
         return $this->nodesScheduledForCreate;
+    }
+
+    /**
+     * @param object $entity
+     *
+     * @return bool
+     */
+    public function isScheduledForCreate($entity)
+    {
+        return isset($this->nodesScheduledForCreate[spl_object_hash($entity)]);
     }
 
     /**
@@ -641,6 +715,16 @@ class UnitOfWork
     public function getNodesScheduledForDelete()
     {
         return $this->nodesScheduledForDelete;
+    }
+
+    /**
+     * @param object $entity
+     *
+     * @return bool
+     */
+    public function isScheduledForDelete($entity)
+    {
+        return isset($this->nodesScheduledForDelete[spl_object_hash($entity)]);
     }
 
     /**

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -21,6 +21,10 @@ use GraphAware\Neo4j\OGM\Persister\FlushOperationProcessor;
 use GraphAware\Neo4j\OGM\Persister\RelationshipEntityPersister;
 use GraphAware\Neo4j\OGM\Persister\RelationshipPersister;
 
+/**
+ * @author Christophe Willemsen <christophe@graphaware.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
 class UnitOfWork
 {
     const STATE_NEW = 'STATE_NEW';
@@ -549,7 +553,7 @@ class UnitOfWork
             return self::STATE_NEW;
         }
 
-        throw new \LogicException('entity state cannot be assumed');
+        return self::STATE_DETACHED;
     }
 
     public function addManaged($entity)
@@ -579,10 +583,12 @@ class UnitOfWork
     private function removeManaged($entity)
     {
         $oid = spl_object_hash($entity);
+        unset($this->entityIds[$oid]);
+
         $classMetadata = $this->entityManager->getClassMetadataFor(get_class($entity));
         $id = $classMetadata->getIdValue($entity);
         if (null === $id) {
-            throw new \LogicException('Entity marked for managed but couldnt find identity');
+            throw new \LogicException('Entity marked as not managed but could not find identity');
         }
 
         unset($this->entityIds[$oid]);

--- a/tests/Integration/UnitOfWorkTest.php
+++ b/tests/Integration/UnitOfWorkTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration;
+
+use GraphAware\Neo4j\OGM\Tests\Integration\Model\AuthUser;
+use GraphAware\Neo4j\OGM\Tests\Integration\Model\Movie;
+use GraphAware\Neo4j\OGM\Tests\Integration\Model\User;
+
+class UnitOfWorkTest extends IntegrationTestCase
+{
+    public function testContains()
+    {
+        $user = new User('neo', 33);
+        $this->assertFalse($this->em->contains($user));
+
+        $this->em->persist($user);
+        $this->assertTrue($this->em->contains($user));
+
+        $this->em->flush();
+        $this->assertTrue($this->em->contains($user));
+    }
+
+    public function testDetach()
+    {
+        $user = new User('neo', 33);
+        $friend = new User('Trinity', 31);
+        $user->addLovedBy($friend);
+        $this->em->persist($user);
+        $this->em->persist($user);
+        $this->em->flush();
+
+        $this->em->detach($user);
+
+        $this->assertFalse($this->em->contains($user));
+        $this->assertFalse($this->em->contains($friend));
+    }
+}


### PR DESCRIPTION
This will only fix the EntityManager::contains() and EntityManager::detach()

I have delegated merge, detach, refresh and initializeObject down to the unit of work. The unit of work will trigger an error. 


Related to #5. 

