### PR TITLE
Fixed incorrect annotation for $born (int)

### DIFF
--- a/docs/_code/movies/Person.php
+++ b/docs/_code/movies/Person.php
@@ -23,7 +23,7 @@ class Person
     protected $name;
 
     /**
-     * @OGM\Property(type="born")
+     * @OGM\Property(type="int")
      * @var int
      */
     protected $born;


### PR DESCRIPTION
The OGM annotation for $born was "born" instead of "int".    This caused the following error (fixed with my changes):

PHP Fatal error:  Uncaught Doctrine\Common\Annotations\AnnotationException: [Enum Error] Attribute "type" of @GraphAware\Neo4j\OGM\Annotations\Property declared on property Movies\Person::$born accept only [string, boolean, array, int, float], but got born. in /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:168
Stack trace:
#0 /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(773): Doctrine\Common\Annotations\AnnotationException::enumeratorError('type', 'GraphAware\\Neo4...', 'property Movies...', Array, 'born')
#1 /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(663): Doctrine\Common\Annotations\DocParser->Annotation()
#2 /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php(354): Doctrine\Common\Annotations\DocParser->Annotations()
#3 /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/Annotation in /var/www/html/neo4jtest/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php on line 168