### PR TITLE
Fixed code example - missing necessary constructor for example

### DIFF
--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -71,6 +71,16 @@ class Person
     protected $born;
 
     /**
+     * @param string $name
+     * @param int|null $born
+     */
+    public function __construct($name, $born = null)
+    {
+        $this->name = $name;
+        $this->born = $born;
+    }
+
+    /**
      * @return int
      */
     public function getId()


### PR DESCRIPTION
Without the constructor method, the example in the "Persisting new objects" section does not work, it only creates a blank person node.  This example seems to work with a fresh install because these full example code is already included and autoloaded.  But if you try to follow this example as-is in a new namespace, then you run into this issue.