### PR TITLE
Corrected relationship direction in Movie class for actors

### DIFF
--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -451,7 +451,7 @@ class Movie
     ...
 
     /**
-     * @OGM\Relationship(type="ACTED_IN", direction="OUTGOING", targetEntity="Person", collection=true)
+     * @OGM\Relationship(type="ACTED_IN", direction="INCOMING", targetEntity="Person", collection=true)
      * @var ArrayCollection|Person[]
      */
     protected $actors;


### PR DESCRIPTION
When left alone no actors appear in Movie->actors, but when OUTGOING is changed to INCOMING then Movie->actors appears to properly populate.