### PR TITLE
(Similar to #62)  Corrected relationship direction in Movie class for actors

### DIFF
--- a/docs/_code/movies/Movie.php
+++ b/docs/_code/movies/Movie.php
@@ -35,7 +35,7 @@ class Movie
     protected $release;
 
     /**
-     * @OGM\Relationship(type="ACTED_IN", direction="OUTGOING", targetEntity="Person", collection=true)
+     * @OGM\Relationship(type="ACTED_IN", direction="INCOMING", targetEntity="Person", collection=true)
      * @var ArrayCollection|Person[]
      */
     protected $actors;


### PR DESCRIPTION
(Again, with apologies for my ignorance on how to combine multiple edits in different files on GitHub...)  When left alone no actors appear in Movie->actors, but when OUTGOING is changed to INCOMING then Movie->actors appears to properly populate.