### PR TITLE
RelationshipEntity hydration

### DIFF
--- a/src/Hydrator/EntityHydrator.php
+++ b/src/Hydrator/EntityHydrator.php
@@ -11,12 +11,14 @@
 
 namespace GraphAware\Neo4j\OGM\Hydrator;
 
+use GraphAware\Common\Type\Relationship;
 use GraphAware\Common\Result\Record;
 use GraphAware\Common\Result\Result;
 use GraphAware\Common\Type\Node;
 use GraphAware\Neo4j\OGM\Common\Collection;
 use GraphAware\Neo4j\OGM\EntityManager;
 use GraphAware\Neo4j\OGM\Metadata\NodeEntityMetadata;
+use GraphAware\Neo4j\OGM\Metadata\RelationshipEntityMetadata;
 
 class EntityHydrator
 {
@@ -100,6 +102,79 @@ class EntityHydrator
         }
     }
 
+    public function hydrateRelationshipEntity($alias, Result $dbResult, $sourceEntity)
+    {
+        $relationshipMetadata = $this->_classMetadata->getRelationship($alias);
+        /** @var RelationshipEntityMetadata $relationshipEntityMetadata */
+        $relationshipEntityMetadata = $this->_em->getClassMetadataFor($relationshipMetadata->getRelationshipEntityClass());
+        $otherClass = $this->guessOtherClassName($alias);
+        $otherMetadata = $this->_em->getClassMetadataFor($otherClass);
+        $otherHydrator = $this->_em->getEntityHydrator($otherClass);
+
+        // we iterate the result of records which are a map
+        // {target: (Node) , re: (Relationship) }
+        foreach ($dbResult->records() as $record) {
+            $k = $relationshipMetadata->getAlias();
+            /** @var Node $targetNode */
+            $targetNode = $record->get($k)['target'];
+            /** @var Relationship $relationship */
+            $relationship = $record->get($k)['re'];
+
+            // hydrate the target node :
+            $targetEntity = $otherHydrator->hydrateNode($targetNode);
+
+            // create the relationship entity
+            $entity = $this->_em->getUnitOfWork()->createRelationshipEntity(
+                $relationship,
+                $relationshipEntityMetadata->getClassName(),
+                $sourceEntity,
+                $relationshipMetadata->getPropertyName()
+            );
+
+            // set properties on the relationship entity
+            foreach ($relationshipEntityMetadata->getPropertiesMetadata() as $key => $propertyMetadata) {
+                if ($relationship->hasValue($key)) {
+                    $relationshipEntityMetadata->getPropertyMetadata($key)->setValue($entity, $relationship->get($key));
+                }
+            }
+
+            // set the start node
+            if ($relationshipEntityMetadata->getStartNodeClass() === $this->_classMetadata->getClassName()) {
+                $relationshipEntityMetadata->setStartNodeProperty($entity, $sourceEntity);
+            } else {
+                $relationshipEntityMetadata->setStartNodeProperty($entity, $targetEntity);
+            }
+
+            // set the end node
+            if ($relationshipEntityMetadata->getEndNodeClass() === $this->_classMetadata->getClassName()) {
+                $relationshipEntityMetadata->setEndNodeProperty($entity, $sourceEntity);
+            } else {
+                $relationshipEntityMetadata->setEndNodeProperty($entity, $targetEntity);
+            }
+
+            // set the relationship entity on the source entity
+            $relationshipMetadata->setValue($sourceEntity, $entity);
+
+            // guess the name of the property on the other node
+            foreach ($otherMetadata->getRelationships() as $rel) {
+                if ($rel->isRelationshipEntity() && $rel->getRelationshipEntityClass() === $relationshipEntityMetadata->getClassName()) {
+                    $rel->setValue($targetEntity, $entity);
+                }
+            }
+        }
+    }
+
+
+    private function guessOtherClassName($alias)
+    {
+        $relationshipMetadata = $this->_classMetadata->getRelationship($alias);
+        /** @var RelationshipEntityMetadata $relationshipEntityMetadata */
+        $relationshipEntityMetadata = $this->_em->getClassMetadataFor($relationshipMetadata->getRelationshipEntityClass());
+        $inversedSide = $relationshipEntityMetadata->getOtherClassNameForOwningClass($this->_classMetadata->getClassName());
+        /** @todo will not work for Direction.BOTH */
+        return $inversedSide;
+    }
+
     private function initRelationshipCollection($alias, $sourceEntity)
     {
         $this->_classMetadata->getRelationship($alias)->initializeCollection($sourceEntity);
@@ -131,8 +206,9 @@ class EntityHydrator
         }
     }
 
-    protected function hydrateNode(Node $node, $class)
+    protected function hydrateNode(Node $node, $class = null)
     {
+        $cm = null === $class ? $this->_classMetadata->getClassName() : $class;
         $id = $node->identity();
 
         // Check the entity is not managed yet by the uow
@@ -141,7 +217,7 @@ class EntityHydrator
         }
 
         // create the entity
-        $entity = $this->_em->getUnitOfWork()->createEntity($node, $class, $id);
+        $entity = $this->_em->getUnitOfWork()->createEntity($node, $cm, $id);
         $this->hydrateProperties($entity, $node);
 
         return $entity;

--- a/src/Metadata/NodeEntityMetadata.php
+++ b/src/Metadata/NodeEntityMetadata.php
@@ -196,6 +196,8 @@ final class NodeEntityMetadata extends GraphEntityMetadata
         if (array_key_exists($key, $this->relationships)) {
             return $this->relationships[$key];
         }
+
+        return null;
     }
 
     /**

--- a/src/Metadata/RelationshipEntityMetadata.php
+++ b/src/Metadata/RelationshipEntityMetadata.php
@@ -154,6 +154,34 @@ final class RelationshipEntityMetadata extends GraphEntityMetadata
         return null;
     }
 
+    public function getOtherClassNameForOwningClass($class)
+    {
+        if ($this->startNodeEntityMetadata === $class) {
+            return $this->endNodeEntityMetadata;
+        }
+
+        return $this->startNodeEntityMetadata;
+    }
+
+    public function getInversedSide($name)
+    {
+        if ($this->startNodeReflectionProperty->getName() === $name) {
+            return $this->endNodeReflectionProperty;
+        }
+
+        return $this->startNodeReflectionProperty;
+    }
+
+    public function getStartNodeClass()
+    {
+        return $this->startNodeEntityMetadata;
+    }
+
+    public function getEndNodeClass()
+    {
+        return $this->endNodeEntityMetadata;
+    }
+
     public function isAssociationInverseSide($assocName)
     {
         // Not implemented

--- a/src/Persister/RelationshipEntityPersister.php
+++ b/src/Persister/RelationshipEntityPersister.php
@@ -59,7 +59,8 @@ class RelationshipEntityPersister
         if (!empty($parameters['fields'])) {
             $query .= 'SET r += {fields} ';
         }
-        $query .= 'RETURN id(r) as id';
+        $query .= 'RETURN id(r) AS id, {oid} AS oid';
+        $parameters['oid'] = spl_object_hash($entity);
 
         return Statement::create($query, $parameters);
     }

--- a/src/Persister/RelationshipEntityPersister.php
+++ b/src/Persister/RelationshipEntityPersister.php
@@ -69,7 +69,7 @@ class RelationshipEntityPersister
     {
         $id = $this->classMetadata->getIdValue($entity);
 
-        $query = sprintf('START rel=rel(%d) SET rel += {fields}', $id);
+        $query = sprintf('MATCH ()-[rel]->() WHERE id(rel) = %d SET rel += {fields}', $id);
 
         $parameters = [
             'fields' => [],
@@ -86,8 +86,9 @@ class RelationshipEntityPersister
     public function getDeleteQuery($entity)
     {
         $id = $this->classMetadata->getIdValue($entity);
-        $query = 'START rel=rel('.$id.') DELETE rel';
+        $query = 'START rel=rel('.$id.') DELETE rel RETURN {oid} AS oid';
+        $params = ['oid' => spl_object_hash($entity)];
 
-        return Statement::create($query);
+        return Statement::create($query, $params);
     }
 }

--- a/src/Persisters/BasicEntityPersister.php
+++ b/src/Persisters/BasicEntityPersister.php
@@ -166,14 +166,14 @@ class BasicEntityPersister
     {
         $relationshipMeta = $this->_classMetadata->getRelationship($alias);
         $relAlias = $relationshipMeta->getAlias();
-        $targetAlias = $this->_em->getClassMetadataFor($relationshipMeta->getTargetEntity())->getEntityAlias();
+        $targetAlias = $this->_em->getClassMetadataFor($relationshipMeta->getRelationshipEntityClass())->getEntityAlias();
         $sourceEntityId = $this->_classMetadata->getIdValue($sourceEntity);
         $relationshipType = $relationshipMeta->getType();
 
         $isIncoming = $relationshipMeta->getDirection() === DirectionUtils::INCOMING ? '<' : '';
         $isOutgoing = $relationshipMeta->getDirection() === DirectionUtils::OUTGOING ? '>' : '';
 
-        $target = $isIncoming ? 'endNode' : 'startNode';
+        $target = $isIncoming ? 'startNode' : 'endNode';
 
         $relPattern = sprintf('%s-[%s:`%s`]-%s', $isIncoming, $relAlias, $relationshipType, $isOutgoing);
 

--- a/src/Persisters/BasicEntityPersister.php
+++ b/src/Persisters/BasicEntityPersister.php
@@ -103,6 +103,15 @@ class BasicEntityPersister
         $hydrator->hydrateSimpleRelationshipCollection($alias, $result, $sourceEntity);
     }
 
+    public function getRelationshipEntity($alias, $sourceEntity)
+    {
+        $stmt = $this->getRelationshipEntityStatement($alias, $sourceEntity);
+        $result = $this->_em->getDatabaseDriver()->run($stmt->text(), $stmt->parameters());
+        $hydrator = $this->_em->getEntityHydrator($this->_className);
+
+        $hydrator->hydrateRelationshipEntity($alias, $result, $sourceEntity);
+    }
+
     /**
      * @param $criteria
      * @param null|int $limit
@@ -149,6 +158,30 @@ class BasicEntityPersister
         $cypher .= 'RETURN '.$targetAlias;
 
         $params = ['id' => (int) $sourceEntityId];
+
+        return Statement::create($cypher, $params);
+    }
+
+    private function getRelationshipEntityStatement($alias, $sourceEntity)
+    {
+        $relationshipMeta = $this->_classMetadata->getRelationship($alias);
+        $relAlias = $relationshipMeta->getAlias();
+        $targetAlias = $this->_em->getClassMetadataFor($relationshipMeta->getTargetEntity())->getEntityAlias();
+        $sourceEntityId = $this->_classMetadata->getIdValue($sourceEntity);
+        $relationshipType = $relationshipMeta->getType();
+
+        $isIncoming = $relationshipMeta->getDirection() === DirectionUtils::INCOMING ? '<' : '';
+        $isOutgoing = $relationshipMeta->getDirection() === DirectionUtils::OUTGOING ? '>' : '';
+
+        $target = $isIncoming ? 'endNode' : 'startNode';
+
+        $relPattern = sprintf('%s-[%s:`%s`]-%s', $isIncoming, $relAlias, $relationshipType, $isOutgoing);
+
+        $cypher  = 'MATCH (n) WHERE id(n) = {id} ';
+        $cypher .= 'MATCH (n)'.$relPattern.'('.$targetAlias.') ';
+        $cypher .= 'RETURN {target: '.$target.'('.$relAlias.'), re: '.$relAlias.'} AS '.$relAlias;
+
+        $params = ['id' => $sourceEntityId];
 
         return Statement::create($cypher, $params);
     }

--- a/src/Persisters/BasicEntityPersister.php
+++ b/src/Persisters/BasicEntityPersister.php
@@ -107,6 +107,18 @@ class BasicEntityPersister
     {
         $stmt = $this->getRelationshipEntityStatement($alias, $sourceEntity);
         $result = $this->_em->getDatabaseDriver()->run($stmt->text(), $stmt->parameters());
+        if ($result->size() > 1) {
+            throw new \RuntimeException(sprintf('Expected 1 result, got %d', $result->size()));
+        }
+        $hydrator = $this->_em->getEntityHydrator($this->_className);
+
+        $hydrator->hydrateRelationshipEntity($alias, $result, $sourceEntity);
+    }
+
+    public function getRelationshipEntityCollection($alias, $sourceEntity)
+    {
+        $stmt = $this->getRelationshipEntityStatement($alias, $sourceEntity);
+        $result = $this->_em->getDatabaseDriver()->run($stmt->text(), $stmt->parameters());
         $hydrator = $this->_em->getEntityHydrator($this->_className);
 
         $hydrator->hydrateRelationshipEntity($alias, $result, $sourceEntity);

--- a/src/Proxy/NodeCollectionInitializer.php
+++ b/src/Proxy/NodeCollectionInitializer.php
@@ -22,22 +22,4 @@ class NodeCollectionInitializer extends SingleNodeInitializer
         $persister = $this->em->getEntityPersister($this->metadata->getClassName());
         $persister->getSimpleRelationshipCollection($this->relationshipMetadata->getPropertyName(), $baseInstance);
     }
-
-    public function handleResult(Result $result)
-    {
-        $instances = new ArrayCollection();
-        $class = $class = $this->relationshipMetadata->getDirection() === 'INCOMING' ? $this->metadata->getClassName() : $this->relationshipMetadata->getTargetEntity();
-        $cm = $this->em->getClassMetadata($class);
-        foreach ($result->records() as $record) {
-            $o = count($cm->getRelationships()) > 1
-                ? $this->em->getProxyFactory($cm)->fromNode($record->get($this->relationshipMetadata->getPropertyName()))
-                : $this->em->getRepository($class)->hydrate($record, false, $this->relationshipMetadata->getPropertyName());
-            $otherNodeMeta = $this->em->getClassMetadataFor($this->relationshipMetadata->getTargetEntity());
-            $this->em->getHydrator($class)->populateDataToInstance($record->get($this->relationshipMetadata->getPropertyName()), $otherNodeMeta, $o);
-            $instances->add($o);
-        }
-
-        return $instances;
-    }
-
 }

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -42,6 +42,14 @@ class ProxyFactory
                 $initializers[$relationship->getPropertyName()] = $initializer;
             }
         }
+        foreach ($this->classMetadata->getRelationshipEntities() as $relationshipEntity) {
+            if (!$relationshipEntity->isCollection()) {
+                if (!in_array($relationshipEntity->getPropertyName(), $mappedByProperties)) {
+                    $initializer = new RelationshipEntityInitializer($this->em, $relationshipEntity, $this->classMetadata);
+                    $initializers[$relationshipEntity->getPropertyName()] = $initializer;
+                }
+            }
+        }
         $object->__setInitializers($initializers);
         foreach ($mappedByProperties as $mappedByProperty) {
             $object->__setInitialized($mappedByProperty);

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -48,6 +48,11 @@ class ProxyFactory
                     $initializer = new RelationshipEntityInitializer($this->em, $relationshipEntity, $this->classMetadata);
                     $initializers[$relationshipEntity->getPropertyName()] = $initializer;
                 }
+            } else {
+                if (!in_array($relationshipEntity->getPropertyName(), $mappedByProperties)) {
+                    $initializer = new RelationshipEntityCollectionInitializer($this->em, $relationshipEntity, $this->classMetadata);
+                    $initializers[$relationshipEntity->getPropertyName()] = $initializer;
+                }
             }
         }
         $object->__setInitializers($initializers);

--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -37,7 +37,7 @@ class ProxyFactory
         $object->__setNode($node);
         $initializers = [];
         foreach ($this->classMetadata->getSimpleRelationships() as $relationship) {
-            if (!$relationship->isFetch() && !in_array($relationship->getPropertyName(), $mappedByProperties)) {
+            if (!in_array($relationship->getPropertyName(), $mappedByProperties)) {
                 $initializer = $this->getInitializerFor($relationship);
                 $initializers[$relationship->getPropertyName()] = $initializer;
             }

--- a/src/Proxy/RelationshipEntityCollectionInitializer.php
+++ b/src/Proxy/RelationshipEntityCollectionInitializer.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the GraphAware Neo4j PHP OGM package.
+ *
+ * (c) GraphAware Ltd <info@graphaware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GraphAware\Neo4j\OGM\Proxy;
+
+use GraphAware\Common\Type\Node;
+
+class RelationshipEntityCollectionInitializer extends RelationshipEntityInitializer
+{
+    public function initialize(Node $node, $baseInstance)
+    {
+        $persister = $this->em->getEntityPersister($this->metadata->getClassName());
+        $persister->getRelationshipEntityCollection($this->relationshipMetadata->getPropertyName(), $baseInstance);
+    }
+
+}

--- a/src/Proxy/RelationshipEntityInitializer.php
+++ b/src/Proxy/RelationshipEntityInitializer.php
@@ -18,6 +18,6 @@ class RelationshipEntityInitializer extends SingleNodeInitializer
     public function initialize(Node $node, $baseInstance)
     {
         $persister = $this->em->getEntityPersister($this->metadata->getClassName());
-        $persister->getRelationshipEntity($this->relationshipMetadata, $baseInstance);
+        $persister->getRelationshipEntity($this->relationshipMetadata->getPropertyName(), $baseInstance);
     }
 }

--- a/src/Proxy/RelationshipEntityInitializer.php
+++ b/src/Proxy/RelationshipEntityInitializer.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the GraphAware Neo4j PHP OGM package.
+ *
+ * (c) GraphAware Ltd <info@graphaware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GraphAware\Neo4j\OGM\Proxy;
+
+use GraphAware\Common\Type\Node;
+
+class RelationshipEntityInitializer extends SingleNodeInitializer
+{
+    public function initialize(Node $node, $baseInstance)
+    {
+        $persister = $this->em->getEntityPersister($this->metadata->getClassName());
+        $persister->getRelationshipEntity($this->relationshipMetadata, $baseInstance);
+    }
+}

--- a/src/Proxy/SingleNodeInitializer.php
+++ b/src/Proxy/SingleNodeInitializer.php
@@ -37,47 +37,4 @@ class SingleNodeInitializer
         $persister = $this->em->getEntityPersister($this->metadata->getClassName());
         $persister->getSimpleRelationship($this->relationshipMetadata->getPropertyName(), $baseInstance);
     }
-
-    protected function getRelQueryPart()
-    {
-        switch ($this->relationshipMetadata->getDirection()) {
-            case 'INCOMING':
-                $relStr = '<-[rel_%s:%s]-';
-                break;
-            case 'OUTGOING':
-                $relStr = '-[rel_%s:%s]->';
-                break;
-            default:
-                $relStr = '-[rel_%s:%s]-';
-                break;
-        }
-
-        $relationshipType = $this->relationshipMetadata->getType();
-        $relQueryPart = sprintf($relStr, strtolower($relationshipType), $relationshipType);
-
-        return $relQueryPart;
-    }
-
-    public function handleResult(Result $result)
-    {
-        if ($result->size() === 0) {
-            return null;
-        }
-
-        if ($result->size() > 1) {
-            throw new \RuntimeException(sprintf('Expected only 1 result, got %d', $result->size()));
-        }
-
-        $class = $this->relationshipMetadata->getDirection() === 'INCOMING' ? $this->metadata->getClassName() : $this->relationshipMetadata->getTargetEntity();
-        $cm = $this->em->getClassMetadata($class);
-
-        if (count($cm->getRelationships()) > 0) {
-            $o = $this->em->getProxyFactory($cm)->fromNode($result->firstRecord()->get('n'), array($this->relationshipMetadata->getMappedByProperty()));
-            $this->em->getHydrator($this->metadata->getClassName())->populateDataToInstance($result->firstRecord()->get('n'), $this->metadata, $o);
-
-            return $o;
-        }
-
-        return $this->em->getRepository($class)->hydrate($result->firstRecord(), false);
-    }
 }

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use GraphAware\Common\Result\ResultCollection;
 use GraphAware\Common\Type\Node;
+use GraphAware\Common\Type\Relationship;
 use GraphAware\Neo4j\Client\Stack;
 use GraphAware\Neo4j\OGM\Exception\OGMInvalidArgumentException;
 use GraphAware\Neo4j\OGM\Metadata\NodeEntityMetadata;
@@ -983,6 +984,18 @@ class UnitOfWork
         $this->addManaged($entity);
 
         return $entity;
+    }
+
+    public function createRelationshipEntity(Relationship $relationship, $className, $sourceEntity, $field)
+    {
+        $classMetadata = $this->entityManager->getClassMetadataFor($className);
+        $o = $classMetadata->newInstance();
+        $oid = spl_object_hash($o);
+        $this->originalEntityData[$oid] = $relationship->values();
+        $classMetadata->setId($o, $relationship->identity());
+        $this->addManagedRelationshipEntity($o, $sourceEntity, $field);
+
+        return $o;
     }
 
     private function newInstance(NodeEntityMetadata $class, Node $node)

--- a/tests/Integration/Models/OneToManyRE/Acquisition.php
+++ b/tests/Integration/Models/OneToManyRE/Acquisition.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+
+/**
+ * Class Acquisition
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE
+ *
+ * @OGM\RelationshipEntity(type="ACQUIRED")
+ */
+class Acquisition
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\StartNode(targetEntity="Owner")
+     *
+     * @var Owner
+     */
+    protected $owner;
+
+    /**
+     * @OGM\EndNode(targetEntity="House")
+     *
+     * @var House
+     */
+    protected $house;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var int
+     */
+    protected $year;
+
+    /**
+     * Acquisition constructor.
+     * @param Owner $owner
+     * @param House $house
+     * @param int $year
+     */
+    public function __construct(Owner $owner, House $house, $year)
+    {
+        $this->owner = $owner;
+        $this->house = $house;
+        $this->year = $year;
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Owner
+     */
+    public function getOwner()
+    {
+        return $this->owner;
+    }
+
+    /**
+     * @param Owner $owner
+     */
+    public function setOwner($owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * @return House
+     */
+    public function getHouse()
+    {
+        return $this->house;
+    }
+
+    /**
+     * @param House $house
+     */
+    public function setHouse($house)
+    {
+        $this->house = $house;
+    }
+
+    /**
+     * @return int
+     */
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    /**
+     * @param int $year
+     */
+    public function setYear($year)
+    {
+        $this->year = $year;
+    }
+}

--- a/tests/Integration/Models/OneToManyRE/House.php
+++ b/tests/Integration/Models/OneToManyRE/House.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+
+/**
+ * Class House
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE
+ *
+ * @OGM\Node(label="House")
+ */
+class House
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\Relationship(relationshipEntity="Acquisition", type="ACQUIRED", direction="INCOMING")
+     *
+     * @var Acquisition
+     */
+    protected $acquisition;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var string
+     */
+    protected $address;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Acquisition
+     */
+    public function getAcquisition()
+    {
+        return $this->acquisition;
+    }
+
+    /**
+     * @param Acquisition $acquisition
+     */
+    public function setAcquisition($acquisition)
+    {
+        $this->acquisition = $acquisition;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param string $address
+     */
+    public function setAddress($address)
+    {
+        $this->address = $address;
+    }
+}

--- a/tests/Integration/Models/OneToManyRE/Owner.php
+++ b/tests/Integration/Models/OneToManyRE/Owner.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+use GraphAware\Neo4j\OGM\Common\Collection;
+
+/**
+ * Class Owner
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE
+ *
+ * @OGM\Node(label="Owner")
+ */
+class Owner
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @OGM\Relationship(relationshipEntity="Acquisition", type="ACQUIRED", direction="OUTGOING", collection=true)
+     *
+     * @var Acquisition[]|Collection
+     */
+    protected $acquisitions;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+        $this->acquisitions = new Collection();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return Collection|Acquisition[]
+     */
+    public function getAcquisitions()
+    {
+        return $this->acquisitions;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getAcquisitionByAddress($address)
+    {
+        foreach ($this->getAcquisitions() as $acquisition) {
+            if ($acquisition->getHouse()->getAddress() === $address) {
+                return $acquisition;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Models/SimpleRelationshipEntity/Guest.php
+++ b/tests/Integration/Models/SimpleRelationshipEntity/Guest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+
+/**
+ * Class Guest
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity
+ *
+ * @OGM\Node(label="Guest")
+ */
+class Guest
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @OGM\Relationship(relationshipEntity="Rating", type="RATED", direction="OUTGOING")
+     *
+     * @var Rating
+     */
+    protected $rating;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Rating
+     */
+    public function getRating()
+    {
+        return $this->rating;
+    }
+
+    /**
+     * @param Rating $rating
+     */
+    public function setRating($rating)
+    {
+        $this->rating = $rating;
+    }
+
+
+}

--- a/tests/Integration/Models/SimpleRelationshipEntity/Hotel.php
+++ b/tests/Integration/Models/SimpleRelationshipEntity/Hotel.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+
+class Hotel
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @OGM\Relationship(relationshipEntity="Rating", type="RATED", direction="INCOMING")
+     *
+     * @var Rating
+     */
+    protected $rating;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Rating
+     */
+    public function getRating()
+    {
+        return $this->rating;
+    }
+
+    /**
+     * @param Rating $rating
+     */
+    public function setRating($rating)
+    {
+        $this->rating = $rating;
+    }
+
+}

--- a/tests/Integration/Models/SimpleRelationshipEntity/Hotel.php
+++ b/tests/Integration/Models/SimpleRelationshipEntity/Hotel.php
@@ -4,6 +4,12 @@ namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity
 
 use GraphAware\Neo4j\OGM\Annotations as OGM;
 
+/**
+ * Class Hotel
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity
+ *
+ * @OGM\Node(label="Hotel")
+ */
 class Hotel
 {
     /**

--- a/tests/Integration/Models/SimpleRelationshipEntity/Rating.php
+++ b/tests/Integration/Models/SimpleRelationshipEntity/Rating.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity;
+
+use GraphAware\Neo4j\OGM\Annotations as OGM;
+
+/**
+ * Class Rating
+ * @package GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity
+ *
+ * @OGM\RelationshipEntity(type="RATED")
+ */
+class Rating
+{
+    /**
+     * @OGM\GraphId()
+     *
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @OGM\StartNode(targetEntity="Guest")
+     *
+     * @var Guest
+     */
+    protected $guest;
+
+    /**
+     * @OGM\EndNode(targetEntity="Hotel")
+     *
+     * @var Hotel
+     */
+    protected $hotel;
+
+    /**
+     * @OGM\Property()
+     *
+     * @var float
+     */
+    protected $score;
+
+    /**
+     * @param Guest $guest
+     * @param Hotel $hotel
+     * @param float $score
+     */
+    public function __construct(Guest $guest, Hotel $hotel, $score)
+    {
+        $this->guest = $guest;
+        $this->hotel = $hotel;
+        $this->score = $score;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Guest
+     */
+    public function getGuest()
+    {
+        return $this->guest;
+    }
+
+    /**
+     * @param Guest $guest
+     */
+    public function setGuest($guest)
+    {
+        $this->guest = $guest;
+    }
+
+    /**
+     * @return Hotel
+     */
+    public function getHotel()
+    {
+        return $this->hotel;
+    }
+
+    /**
+     * @param Hotel $hotel
+     */
+    public function setHotel($hotel)
+    {
+        $this->hotel = $hotel;
+    }
+
+    /**
+     * @return float
+     */
+    public function getScore()
+    {
+        return $this->score;
+    }
+
+    /**
+     * @param float $score
+     */
+    public function setScore($score)
+    {
+        $this->score = $score;
+    }
+
+
+}

--- a/tests/Integration/OneToManyRelationshipEntityTest.php
+++ b/tests/Integration/OneToManyRelationshipEntityTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration;
+
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE\Acquisition;
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE\House;
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\OneToManyRE\Owner;
+
+/**
+ * Class OneToManyRelationshipEntityTest
+ * @package GraphAware\Neo4j\OGM\Tests\Integration
+ *
+ * @group rel-entity-o2m
+ */
+class OneToManyRelationshipEntityTest extends IntegrationTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->clearDb();
+    }
+
+    public function testOwnerAndMultipleAcquisitionsArePersisted()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $house2 = new House();
+        $house2->setAddress('B Street 2');
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house1, 1969));
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house2, 1978));
+        $this->em->persist($owner);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1969}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1978}]->(h:House {address: "B Street 2"})');
+    }
+
+    public function testOwnerWithMultipleAcquisitionsCanModifyAcquisition()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $house2 = new House();
+        $house2->setAddress('B Street 2');
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house1, 1969));
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house2, 1978));
+        $this->em->persist($owner);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1969}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1978}]->(h:House {address: "B Street 2"})');
+        foreach ($owner->getAcquisitions() as $acquisition) {
+            $acquisition->setYear(2008);
+        }
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 2008}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 2008}]->(h:House {address: "B Street 2"})');
+    }
+
+    public function testOwnerCanBeLoadedWithMultipleAcquisitions()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $house2 = new House();
+        $house2->setAddress('B Street 2');
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house1, 1969));
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house2, 1978));
+        $this->em->persist($owner);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1969}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1978}]->(h:House {address: "B Street 2"})');
+        $this->em->clear();
+
+        /** @var Owner $m */
+        $m = $this->em->getRepository(Owner::class)->findOneBy(['name' => 'M']);
+        $this->assertInstanceOf(Owner::class, $m);
+        $this->assertCount(2, $m->getAcquisitions());
+        foreach ($m->getAcquisitions() as $acquisition) {
+            $this->assertEquals(spl_object_hash($m), spl_object_hash($acquisition->getHouse()->getAcquisition()->getOwner()));
+        }
+    }
+
+    public function testOwnerLoadedWithMultipleAcquisitionsCanModify()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $house2 = new House();
+        $house2->setAddress('B Street 2');
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house1, 1969));
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house2, 1978));
+        $this->em->persist($owner);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1969}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1978}]->(h:House {address: "B Street 2"})');
+        $this->em->clear();
+
+        /** @var Owner $m */
+        $m = $this->em->getRepository(Owner::class)->findOneBy(['name' => 'M']);
+        $this->assertInstanceOf(Owner::class, $m);
+        $this->assertCount(2, $m->getAcquisitions());
+        foreach ($m->getAcquisitions() as $acquisition) {
+            $acquisition->setYear(2000);
+        }
+        $this->em->flush();
+    }
+
+    public function testOwnerLoadedWithMultipleAcquisitionsCanRemoveOne()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $house2 = new House();
+        $house2->setAddress('B Street 2');
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house1, 1969));
+        $owner->getAcquisitions()->add(new Acquisition($owner, $house2, 1978));
+        $this->em->persist($owner);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1969}]->(h:House {address: "A Street 1"})');
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1978}]->(h:House {address: "B Street 2"})');
+        $this->em->clear();
+
+        /** @var Owner $m */
+        $m = $this->em->getRepository(Owner::class)->findOneBy(['name' => 'M']);
+        $this->assertInstanceOf(Owner::class, $m);
+        $this->assertCount(2, $m->getAcquisitions());
+        $a = $m->getAcquisitions()[0];
+        $m->getAcquisitions()->removeElement($a);
+        $this->em->remove($a);
+        $this->em->flush();
+        // Checks that a second flush is safe
+        $this->em->flush();
+    }
+
+    public function testOwnerCanAddOneToCollection()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $this->persist($owner, $house1);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})');
+        $this->assertGraphExist('(h:House {address: "A Street 1"})');
+        $acquisition = new Acquisition($owner, $house1, 1981);
+        $owner->getAcquisitions()->add($acquisition);
+        $house1->setAcquisition($acquisition);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1981}]->(h:House {address: "A Street 1"})');
+    }
+
+    public function testOwnerCanAddOneToCollectionAfterLoad()
+    {
+        $owner = new Owner('M');
+        $house1 = new House();
+        $house1->setAddress('A Street 1');
+        $this->persist($owner, $house1);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})');
+        $this->assertGraphExist('(h:House {address: "A Street 1"})');
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var Owner $me */
+        $me = $this->em->getRepository(Owner::class)->findOneBy(['name' => 'M']);
+        /** @var House $house */
+        $house = $this->em->getRepository(House::class)->findOneBy(['address' => 'A Street 1']);
+        $a = new Acquisition($me, $house, 1980);
+        $me->getAcquisitions()->add($a);
+        $this->em->flush();
+        $this->assertGraphExist('(o:Owner {name:"M"})-[r:ACQUIRED {year: 1980}]->(h:House {address: "A Street 1"})');
+        // assert second flush is safe
+        $this->em->flush();
+        $result = $this->client->run('MATCH (o:Owner)-[r:ACQUIRED]->(h) RETURN count(r) AS c');
+        $this->assertEquals(1, $result->firstRecord()->get('c'));
+    }
+}

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -20,7 +20,42 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $this->clearDb();
     }
 
+    /**
+     * @group simple-re-1
+     */
     public function testRatingCanBetweenGuestAndHotelIsCreated()
+    {
+        $guest = new Guest('john');
+        $hotel = new Hotel('Crowne');
+        $rating = new Rating($guest, $hotel, 3.5);
+        $guest->setRating($rating);
+        $this->em->persist($guest);
+        $this->em->persist($rating);
+        $this->em->flush();
+        $this->assertGraphExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
+        $this->assertNotNull($rating->getId());
+    }
+
+    public function testRatingCanBeAddedOnManagedEntities()
+    {
+        $guest = new Guest('john');
+        $hotel = new Hotel('Crowne');
+        $this->persist($guest, $hotel);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var Guest $john */
+        $john = $this->em->getRepository(Guest::class)->findOneBy(['name' => 'john']);
+        /** @var Hotel $crowne */
+        $crowne = $this->em->getRepository(Hotel::class)->findOneBy(['name' => 'Crowne']);
+
+        $rating = new Rating($john, $crowne, 4.8);
+        $john->setRating($rating);
+        $this->em->flush();
+        $this->assertGraphExist('(g:Guest {name:"john"})-[:RATED {score: 4.8}]->(h:Hotel {name:"Crowne"})');
+    }
+
+    public function testRatingIsRemovedWhenUnreferenced()
     {
         $guest = new Guest('john');
         $hotel = new Hotel('Crowne');
@@ -29,5 +64,9 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $this->em->persist($guest);
         $this->em->flush();
         $this->assertGraphExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
+        $guest->setRating(null);
+        $hotel->setRating(null);
+        $this->em->remove($rating);
+        $this->em->flush();
     }
 }

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -71,6 +71,9 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $this->assertGraphNotExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
     }
 
+    /**
+     * @group simple-re-load
+     */
     public function testRatingCanBeLoaded()
     {
         $this->client->run('CREATE (g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -25,6 +25,9 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $guest = new Guest('john');
         $hotel = new Hotel('Crowne');
         $rating = new Rating($guest, $hotel, 3.5);
+        $guest->setRating($rating);
         $this->em->persist($guest);
+        $this->em->flush();
+        $this->assertGraphExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
     }
 }

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -81,5 +81,8 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $guest = $this->em->getRepository(Guest::class)->findOneBy(['name' => 'john']);
         $this->assertInstanceOf(Guest::class, $guest);
         $this->assertInstanceOf(Rating::class, $guest->getRating());
+        $this->assertInstanceOf(Hotel::class, $guest->getRating()->getHotel());
+        $this->assertEquals(3.5, $guest->getRating()->getScore());
+        $this->assertEquals(spl_object_hash($guest), spl_object_hash($guest->getRating()->getHotel()->getRating()->getGuest()));
     }
 }

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -70,4 +70,13 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $this->em->flush();
         $this->assertGraphNotExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
     }
+
+    public function testRatingCanBeLoaded()
+    {
+        $this->client->run('CREATE (g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
+        /** @var Guest $guest */
+        $guest = $this->em->getRepository(Guest::class)->findOneBy(['name' => 'john']);
+        $this->assertInstanceOf(Guest::class, $guest);
+        $this->assertInstanceOf(Rating::class, $guest->getRating());
+    }
 }

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -55,7 +55,7 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $this->assertGraphExist('(g:Guest {name:"john"})-[:RATED {score: 4.8}]->(h:Hotel {name:"Crowne"})');
     }
 
-    public function testRatingIsRemovedWhenUnreferenced()
+    public function testRatingCanBeRemoved()
     {
         $guest = new Guest('john');
         $hotel = new Hotel('Crowne');
@@ -68,5 +68,6 @@ class SimpleRelationshipEntityTest extends IntegrationTestCase
         $hotel->setRating(null);
         $this->em->remove($rating);
         $this->em->flush();
+        $this->assertGraphNotExist('(g:Guest {name:"john"})-[:RATED {score: 3.5}]->(h:Hotel {name:"Crowne"})');
     }
 }

--- a/tests/Integration/SimpleRelationshipEntityTest.php
+++ b/tests/Integration/SimpleRelationshipEntityTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration;
+
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity\Guest;
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity\Hotel;
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\SimpleRelationshipEntity\Rating;
+
+/**
+ * Class SimpleRelationshipEntityTest
+ * @package GraphAware\Neo4j\OGM\Tests\Integration
+ *
+ * @group simple-re
+ */
+class SimpleRelationshipEntityTest extends IntegrationTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->clearDb();
+    }
+
+    public function testRatingCanBetweenGuestAndHotelIsCreated()
+    {
+        $guest = new Guest('john');
+        $hotel = new Hotel('Crowne');
+        $rating = new Rating($guest, $hotel, 3.5);
+        $this->em->persist($guest);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/graphaware/neo4j-php-ogm/projects/1#card-1858747

This PR intention is to bring back Relationship Entity functionality after the Proxy refactoring.

* RelationshipEntity on a non-collection property can be added
* RelationshipEntity on a non-collection property can be removed
* RelationshipEntity properties can be modified
* RelationshipEntity can be loaded along with a product (via proxy)
* Loaded RelationshipEntity can be modified
* Loaded RelationshipEntity can be removed

Note that, as RE's re `Entities`, they are not cascade removed by reference, a manual `$entityManager->remove($entity);` should be performed and the RE will be removed on the next `flush()`