### PR TITLE
Make sure the parent class exists before creating a proxy method

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -127,14 +127,14 @@ PROXY;
             if ($relationship->isFetch()) {
                 continue;
             }
-            $g = 'get'.ucfirst($relationship->getPropertyName());
             $getter = 'get'.ucfirst($relationship->getPropertyName()).'()';
             $returnStr = $getter;
 
             if (PHP_VERSION_ID > 70000) {
                 $reflClass = new \ReflectionClass($this->classMetadata->getClassName());
-                $reflMethod = $reflClass->getMethod($g);
-                if (null !== $reflMethod) {
+                $g = 'get'.ucfirst($relationship->getPropertyName());
+                if ($reflClass->hasMethod($g)) {
+                    $reflMethod = $reflClass->getMethod($g);
                     if ($reflMethod->hasReturnType()) {
                         $rt = $reflMethod->getReturnType();
                         $getter .= ': '.$rt;

--- a/tests/Proxy/Model/PHP7/User.php
+++ b/tests/Proxy/Model/PHP7/User.php
@@ -40,6 +40,14 @@ class User
     protected $profile;
 
     /**
+     * @var Profile
+     * An entity without getter
+     *
+     * @OGM\Relationship(type="HAS_PUBLIC_PROFILE", direction="OUTGOING", targetEntity="Profile")
+     */
+    protected $publicProfile;
+
+    /**
      * User constructor.
      *
      * @param string $login


### PR DESCRIPTION
If one had a property without a getter one should not get a `ReflectionException: Method getPropertyX does not exist` exception thrown at you. 
