### PR TITLE
basic entity persister forgotten filter params cursor change fix

### DIFF
--- a/src/Persisters/BasicEntityPersister.php
+++ b/src/Persisters/BasicEntityPersister.php
@@ -146,6 +146,7 @@ class BasicEntityPersister
             $clause = $filter_cursor === 0 ? 'WHERE' : 'AND';
             $cypher .= sprintf('%s %s.%s = {%s} ', $clause, $identifier, $key, $key);
             $params[$key] = $criterion;
+            ++$filter_cursor;
         }
 
         $cypher .= 'RETURN '.$identifier;


### PR DESCRIPTION
Found out forgotten loop flag update. That leads to multiple `where`'s in query