### PR TITLE
custom cypher query via entity manager

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -364,4 +364,19 @@ class EntityManager implements EntityManagerInterface
     {
         return new BasicEntityPersister($className, $this->getClassMetadataFor($className), $this);
     }
+
+    /**
+     * @param string $cql
+     * @return Query
+     */
+    public function createQuery($cql = '')
+    {
+        $query = new Query($this);
+
+        if (!empty($cql)) {
+            $query->setCQL($cql);
+        }
+
+        return $query;
+    }
 }

--- a/src/Exception/Result/NoResultException.php
+++ b/src/Exception/Result/NoResultException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the GraphAware Neo4j PHP OGM package.
+ *
+ * (c) GraphAware Ltd <info@graphaware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GraphAware\Neo4j\OGM\Exception\Result;
+
+use GraphAware\Neo4j\OGM\Exception\Neo4jOGMException;
+
+class NoResultException extends \RuntimeException implements Neo4jOGMException
+{
+
+}

--- a/src/Exception/Result/NonUniqueResultException.php
+++ b/src/Exception/Result/NonUniqueResultException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the GraphAware Neo4j PHP OGM package.
+ *
+ * (c) GraphAware Ltd <info@graphaware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GraphAware\Neo4j\OGM\Exception\Result;
+
+use GraphAware\Neo4j\OGM\Exception\Neo4jOGMException;
+
+class NonUniqueResultException extends \RuntimeException implements Neo4jOGMException
+{
+
+}

--- a/src/Hydrator/EntityHydrator.php
+++ b/src/Hydrator/EntityHydrator.php
@@ -187,7 +187,7 @@ class EntityHydrator
         }
     }
 
-    protected function hydrateRecord(Record $record, array &$result, $collection = false)
+    public function hydrateRecord(Record $record, array &$result, $collection = false)
     {
         $cqlAliasMap = $this->getAliases();
 
@@ -214,7 +214,7 @@ class EntityHydrator
         }
     }
 
-    protected function hydrateNode(Node $node, $class = null)
+    public function hydrateNode(Node $node, $class = null)
     {
         $cm = null === $class ? $this->_classMetadata->getClassName() : $class;
         $id = $node->identity();

--- a/src/Query.php
+++ b/src/Query.php
@@ -12,6 +12,8 @@
 namespace GraphAware\Neo4j\OGM;
 
 use GraphAware\Common\Result\Result;
+use GraphAware\Neo4j\OGM\Exception\Result\NonUniqueResultException;
+use GraphAware\Neo4j\OGM\Exception\Result\NoResultException;
 
 class Query
 {
@@ -75,8 +77,18 @@ class Query
      */
     public function getOneOrNullResult()
     {
-        /** @todo add getOneOrNullResult feature */
-        return null;
+        $result = $this->execute();
+
+        if (empty($result)) {
+            return null;
+        }
+
+        if (count($result) > 1) {
+            throw new NonUniqueResultException(sprintf('Expected 1 or null result, got %d', count($result)));
+        }
+
+
+        return $result[0];
     }
 
     /**
@@ -84,8 +96,17 @@ class Query
      */
     public function getOneResult()
     {
-        /** @todo add getOneResult feature */
-        return null;
+        $result = $this->execute();
+
+        if (count($result) > 1) {
+            throw new NonUniqueResultException(sprintf('Expected 1 or null result, got %d', count($result)));
+        }
+
+        if (empty($result)) {
+            throw new NoResultException();
+        }
+
+        return $result[0];
     }
 
     /**
@@ -99,14 +120,13 @@ class Query
 
         $result = $this->em->getDatabaseDriver()->run($stmt, $parameters);
         if ($result->size() === 0) {
-            return null;
+            return [];
         }
 
         $cqlResult = $this->handleResult($result);
 
         if (count($this->mappings) === 1) {
             $k = array_keys($this->mappings)[0];
-            var_dump($k);
             return $cqlResult[$k];
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the GraphAware Neo4j PHP OGM package.
+ *
+ * (c) GraphAware Ltd <info@graphaware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GraphAware\Neo4j\OGM;
+
+use GraphAware\Common\Result\Result;
+
+class Query
+{
+    const PARAMETER_LIST = 0;
+
+    const PARAMETER_MAP = 1;
+
+    protected $em;
+
+    protected $cql;
+
+    protected $parameters = [];
+
+    protected $mappings = [];
+
+    /**
+     * @param EntityManager $entityManager
+     */
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->em = $entityManager;
+    }
+
+    /**
+     * @param $cql
+     */
+    public function setCQL($cql)
+    {
+        $this->cql = $cql;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     * @param null|int $type
+     */
+    public function setParameter($key, $value, $type = null)
+    {
+        $this->parameters[$key] = [$value, $type];
+    }
+
+    /**
+     * @param string $alias
+     * @param string $className
+     */
+    public function addEntityMapping($alias, $className)
+    {
+        $this->mappings[$alias] = $className;
+    }
+
+    /**
+     * @return array|mixed
+     */
+    public function getResult()
+    {
+        return $this->execute();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOneOrNullResult()
+    {
+        /** @todo add getOneOrNullResult feature */
+        return null;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOneResult()
+    {
+        /** @todo add getOneResult feature */
+        return null;
+    }
+
+    /**
+     * @return array|mixed
+     * @throws \Exception
+     */
+    public function execute()
+    {
+        $stmt = $this->cql;
+        $parameters = $this->formatParameters();
+
+        $result = $this->em->getDatabaseDriver()->run($stmt, $parameters);
+        if ($result->size() === 0) {
+            return null;
+        }
+
+        $cqlResult = $this->handleResult($result);
+
+        if (count($this->mappings) === 1) {
+            $k = array_keys($this->mappings)[0];
+            var_dump($k);
+            return $cqlResult[$k];
+        }
+
+        return $cqlResult;
+    }
+
+    private function handleResult(Result $result)
+    {
+        $queryResult = [];
+
+        foreach ($result->records() as $record) {
+            $keys = $record->keys();
+            $this->validateKeys($keys);
+
+            foreach ($keys as $key) {
+                $queryResult[$key][] = $this->em->getEntityHydrator($this->mappings[$key])->hydrateNode($record->get($key));
+            }
+        }
+
+        return $queryResult;
+    }
+
+    private function validateKeys(array $keys)
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $this->mappings)) {
+                throw new \RuntimeException(sprintf('The query mapping do not contain a reference for "%s"', $key));
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    private function formatParameters()
+    {
+        $params = [];
+        foreach ($this->parameters as $alias => $parameter) {
+            $params[$alias] = $parameter[0];
+        }
+
+        return $params;
+    }
+}

--- a/tests/Integration/QueryTest.php
+++ b/tests/Integration/QueryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace GraphAware\Neo4j\OGM\Tests\Integration;
+
+use GraphAware\Neo4j\OGM\Tests\Integration\Models\Tree\Level;
+
+/**
+ *
+ * @group query-native
+ */
+class QueryTest extends IntegrationTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->clearDb();
+        $this->createTree();
+    }
+
+    public function testCreateQueryReturnsEntities()
+    {
+        $q = $this->em->createQuery('MATCH (n:Level) WHERE n.code = {code} MATCH (n)-[:PARENT_LEVEL*0..]->(level) RETURN level');
+        $q->addEntityMapping('level', Level::class);
+        $q->setParameter('code', 'l3a');
+
+        /** @var Level[] $levels */
+        $levels = $q->execute();
+        $this->assertCount(4, $levels);
+        $this->assertEquals('root', $levels[3]->getCode());
+        $this->assertCount(2, $levels[3]->getChildren());
+    }
+
+    private function createTree()
+    {
+        /**
+         * (root)
+         * (root)-(l1a)  (root)-(l1b)
+         * (l1a)-(l2a)   (l1a)-(l2b)
+         * (l1b)-(l2c)   (l1b)-(l2d)
+         * (l2c)-(l3a)
+         */
+        $root = new Level('root');
+        $l1a = new Level('l1a');
+        $l1a->setParent($root);
+        $l1b = new Level('l1b');
+        $l1b->setParent($root);
+        $l2a = new Level('l2a');
+        $l2b = new Level('l2b');
+        $l2a->setParent($l1a);
+        $l2b->setParent($l1a);
+        $l2c = new Level('l2c');
+        $l2d = new Level('l2d');
+        $l2c->setParent($l1b);
+        $l2d->setParent($l1b);
+        $l3a = new Level('l3a');
+        $l3a->setParent($l2c);
+        $this->em->persist($root);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}


### PR DESCRIPTION
This PR adds a minimal possibility to have custom queries via the Entity Manager.

For example : 

```php
$q = $this->em->createQuery('MATCH (n:User) WHERE n.age > {age} AND size((n)-[:FOLLOWS]->()) < {maxDegree}') RETURN n AS user;
$q->addEntityMapping('user', User::class);
$q->setParameter('age', 35);
$q->setParameter('maxDegree', 200);

return $q->execute();

// returns an array of User objects

```

cc @theUm @JoeThielen @Nyholm @sts85