### PR TITLE
Property converter

### DIFF
--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -21,7 +21,7 @@ final class Property
 {
     /**
      * @var string
-     * @Enum({"string","boolean","array","int","float"})
+     * @Enum({"string","boolean","array","int","float","datetime"})
      */
     public $type;
 

--- a/src/Hydrator/EntityHydrator.php
+++ b/src/Hydrator/EntityHydrator.php
@@ -19,6 +19,7 @@ use GraphAware\Neo4j\OGM\Common\Collection;
 use GraphAware\Neo4j\OGM\EntityManager;
 use GraphAware\Neo4j\OGM\Metadata\NodeEntityMetadata;
 use GraphAware\Neo4j\OGM\Metadata\RelationshipEntityMetadata;
+use GraphAware\Neo4j\OGM\Util\Converters\PropertyConverterFactory;
 
 class EntityHydrator
 {
@@ -248,7 +249,9 @@ class EntityHydrator
         foreach ($node->keys() as $key) {
             if ($this->_classMetadata->hasField($key)) {
                 $propertyMeta = $this->_classMetadata->getPropertyMetadata($key);
-                $propertyMeta->setValue($object, $node->get($key));
+                $converter = PropertyConverterFactory::getConverter($propertyMeta->getPropertyAnnotationMetadata()->getType());
+                $propertyValue = $converter ? $converter->getEntytiValue($node->get($key)) : $node->get($key);
+                $propertyMeta->setValue($object, $propertyValue);
             }
         }
     }

--- a/src/Persister/EntityPersister.php
+++ b/src/Persister/EntityPersister.php
@@ -41,11 +41,13 @@ class EntityPersister
     }
 
     private function getObjectPropertyValues($object) : array{
+        $propertyValues = [];
         foreach ($this->classMetadata->getPropertiesMetadata() as $field => $meta) {
             $converter = PropertyConverterFactory::getConverter($meta->getPropertyAnnotationMetadata()->getType());
             $propertyValues[$field] = ($converter) ? $converter->getDbValue($meta->getValue($object))
                 : $meta->getValue($object);
         }
+        return $propertyValues;
     }
 
     public function getCreateQuery($object)

--- a/src/Persister/EntityPersister.php
+++ b/src/Persister/EntityPersister.php
@@ -40,7 +40,7 @@ class EntityPersister
         $this->entityManager = $entityManager;
     }
 
-    private function getObjectPropertyValues($object) : array{
+    private function getObjectPropertyValues($object){
         $propertyValues = [];
         foreach ($this->classMetadata->getPropertiesMetadata() as $field => $meta) {
             $converter = PropertyConverterFactory::getConverter($meta->getPropertyAnnotationMetadata()->getType());

--- a/src/Persister/FlushOperationProcessor.php
+++ b/src/Persister/FlushOperationProcessor.php
@@ -14,6 +14,7 @@ namespace GraphAware\Neo4j\OGM\Persister;
 use GraphAware\Neo4j\Client\Stack;
 use GraphAware\Neo4j\OGM\EntityManager;
 use GraphAware\Neo4j\OGM\Metadata\LabeledPropertyMetadata;
+use GraphAware\Neo4j\OGM\Util\Converters\PropertyConverterFactory;
 
 class FlushOperationProcessor
 {
@@ -58,8 +59,15 @@ class FlushOperationProcessor
 
                 $query .= ' RETURN id(n) as id, node.oid as oid';
                 $statements[$lblKey]['query'] = $query;
+                foreach($metadata->getPropertyValuesArray($entity) as $key => $prop)
+                {
+                    $converter = PropertyConverterFactory::getConverter(
+                        $metadata->getPropertyMetadata($key)->getPropertyAnnotationMetadata()->getType()
+                    );
+                    $convertedPropertyValues[$key] = $converter ? $converter->getDbValue($prop) : $prop;
+                }
                 $statements[$lblKey]['nodes'][] = [
-                    'props' => $metadata->getPropertyValuesArray($entity),
+                    'props' => $convertedPropertyValues,
                     'oid' => $oid,
                 ];
             }

--- a/src/Persister/FlushOperationProcessor.php
+++ b/src/Persister/FlushOperationProcessor.php
@@ -59,6 +59,7 @@ class FlushOperationProcessor
 
                 $query .= ' RETURN id(n) as id, node.oid as oid';
                 $statements[$lblKey]['query'] = $query;
+                $convertedPropertyValues = [];
                 foreach($metadata->getPropertyValuesArray($entity) as $key => $prop)
                 {
                     $converter = PropertyConverterFactory::getConverter(

--- a/src/Util/Converters/DateTimeTimestampConverter.php
+++ b/src/Util/Converters/DateTimeTimestampConverter.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: Sobraz
+ * Date: 01/04/2017
+ * Time: 15:44
+ */
+class DateTimeTimestampConverter extends PropertyConverter
+{
+
+    protected function convertToDbValue($entityValue)
+    {
+        /** @var $entityValue \DateTime */
+        return $entityValue->getTimestamp();
+    }
+
+    protected function convertToPropertyEnttityValue($dbvalue)
+    {
+        $datetime = new \DateTime();
+        $datetime->setTimestamp($dbvalue);
+        return $datetime;
+    }
+
+    protected static function getPropertyEntityType() : string
+    {
+        return "\\DateTime";
+    }
+}

--- a/src/Util/Converters/DateTimeTimestampConverter.php
+++ b/src/Util/Converters/DateTimeTimestampConverter.php
@@ -18,8 +18,8 @@ class DateTimeTimestampConverter extends PropertyConverter
         return $datetime;
     }
 
-    protected static function getPropertyEntityType() : string
+    protected function getPropertyEntityType() : string
     {
-        return "\\DateTime";
+        return \DateTime::class;
     }
 }

--- a/src/Util/Converters/DateTimeTimestampConverter.php
+++ b/src/Util/Converters/DateTimeTimestampConverter.php
@@ -1,11 +1,7 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: Sobraz
- * Date: 01/04/2017
- * Time: 15:44
- */
+namespace GraphAware\Neo4j\OGM\Util\Converters;
+
 class DateTimeTimestampConverter extends PropertyConverter
 {
 

--- a/src/Util/Converters/DateTimeTimestampConverter.php
+++ b/src/Util/Converters/DateTimeTimestampConverter.php
@@ -18,7 +18,7 @@ class DateTimeTimestampConverter extends PropertyConverter
         return $datetime;
     }
 
-    protected function getPropertyEntityType() : string
+    protected function getPropertyEntityType()
     {
         return \DateTime::class;
     }

--- a/src/Util/Converters/PropertyConverter.php
+++ b/src/Util/Converters/PropertyConverter.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: Sobraz
+ * Date: 01/04/2017
+ * Time: 15:49
+ */
+abstract  class PropertyConverter
+{
+
+    public function getDbValue($entityValue)
+    {
+        $type = self::getPropertyEntityType();
+        if(!$entityValue instanceof $type)
+            throw new InvalidArgumentException(get_class($this)." cannot convert a ".get_class($entityValue));
+        return $this->convertToDbValue($entityValue);
+    }
+
+    public function getEntytiValue($dbvalue)
+    {
+        return $this->convertToPropertyEnttityValue($dbvalue);
+    }
+
+    protected abstract function convertToDbValue($entityValue);
+    protected abstract function convertToPropertyEnttityValue($dbvalue);
+    protected static abstract function getPropertyEntityType() : string;
+}

--- a/src/Util/Converters/PropertyConverter.php
+++ b/src/Util/Converters/PropertyConverter.php
@@ -22,5 +22,5 @@ abstract  class PropertyConverter
 
     protected abstract function convertToDbValue($entityValue);
     protected abstract function convertToPropertyEnttityValue($dbvalue);
-    protected abstract function getPropertyEntityType() : string;
+    protected abstract function getPropertyEntityType();
 }

--- a/src/Util/Converters/PropertyConverter.php
+++ b/src/Util/Converters/PropertyConverter.php
@@ -1,11 +1,7 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: Sobraz
- * Date: 01/04/2017
- * Time: 15:49
- */
+namespace GraphAware\Neo4j\OGM\Util\Converters;
+
 abstract  class PropertyConverter
 {
 

--- a/src/Util/Converters/PropertyConverter.php
+++ b/src/Util/Converters/PropertyConverter.php
@@ -2,6 +2,8 @@
 
 namespace GraphAware\Neo4j\OGM\Util\Converters;
 
+use InvalidArgumentException;
+
 abstract  class PropertyConverter
 {
 

--- a/src/Util/Converters/PropertyConverter.php
+++ b/src/Util/Converters/PropertyConverter.php
@@ -7,7 +7,7 @@ abstract  class PropertyConverter
 
     public function getDbValue($entityValue)
     {
-        $type = self::getPropertyEntityType();
+        $type = $this->getPropertyEntityType();
         if(!$entityValue instanceof $type)
             throw new InvalidArgumentException(get_class($this)." cannot convert a ".get_class($entityValue));
         return $this->convertToDbValue($entityValue);
@@ -20,5 +20,5 @@ abstract  class PropertyConverter
 
     protected abstract function convertToDbValue($entityValue);
     protected abstract function convertToPropertyEnttityValue($dbvalue);
-    protected static abstract function getPropertyEntityType() : string;
+    protected abstract function getPropertyEntityType() : string;
 }

--- a/src/Util/Converters/PropertyConverterFactory.php
+++ b/src/Util/Converters/PropertyConverterFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: Sobraz
+ * Date: 01/04/2017
+ * Time: 15:45
+ */
+class PropertyConverterFactory
+{
+
+    private static $converters = [
+        "datetime" => "clazz"
+    ];
+
+    public static function getConverter($type) : PropertyConverter
+    {
+        if (!array_key_exists($type, self::$converters))
+            return null;
+        $converter = self::$converters[$type];
+        return new $converter;
+    }
+}

--- a/src/Util/Converters/PropertyConverterFactory.php
+++ b/src/Util/Converters/PropertyConverterFactory.php
@@ -1,11 +1,7 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: Sobraz
- * Date: 01/04/2017
- * Time: 15:45
- */
+namespace GraphAware\Neo4j\OGM\Util\Converters;
+
 class PropertyConverterFactory
 {
 

--- a/src/Util/Converters/PropertyConverterFactory.php
+++ b/src/Util/Converters/PropertyConverterFactory.php
@@ -6,10 +6,10 @@ class PropertyConverterFactory
 {
 
     private static $converters = [
-        "datetime" => "clazz"
+        "datetime" => DateTimeTimestampConverter::class
     ];
 
-    public static function getConverter($type) : PropertyConverter
+    public static function getConverter($type)
     {
         if (!array_key_exists($type, self::$converters))
             return null;

--- a/tests/Util/Converters/DateTimeTimestampConverterTest.php
+++ b/tests/Util/Converters/DateTimeTimestampConverterTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rcollas
+ * Date: 4/3/2017
+ * Time: 11:27 AM
+ */
+
+namespace GraphAware\Neo4j\OGM\Tests\Util\Converters;
+
+use \GraphAware\Neo4j\OGM\Util\Converters\DateTimeTimestampConverter;
+
+use InvalidArgumentException;
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeTimestampConverterTest extends TestCase
+{
+    public function testToTimestampConvertion(){
+        $converter = new DateTimeTimestampConverter();
+        $datetime = new \DateTime("NOW");
+        $converted = $converter->getDbValue($datetime);
+
+        $this->assertTrue($converted == $datetime->getTimestamp());
+    }
+
+    public function testToTimestampConvertionWithInvalidParam(){
+        $this->expectException(InvalidArgumentException::class);
+
+        $converter = new DateTimeTimestampConverter();
+        $invalidObject = new Integer();
+        $converter->getDbValue($invalidObject);
+    }
+
+    public function testToDateTimeConvertion(){
+        $converter = new DateTimeTimestampConverter();
+        $datetime = new \DateTime("NOW");
+        $converted = $converter->getEntytiValue($datetime->getTimestamp());
+
+        $this->assertTrue($converted->getTimestamp() == $datetime->getTimestamp());
+    }
+
+
+}

--- a/tests/Util/Converters/FactoryConverterTest.php
+++ b/tests/Util/Converters/FactoryConverterTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: rcollas
+ * Date: 4/3/2017
+ * Time: 11:22 AM
+ */
+
+namespace GraphAware\Neo4j\OGM\Tests\Util\Converters;
+
+
+use GraphAware\Neo4j\OGM\Util\Converters\DateTimeTimestampConverter;
+use GraphAware\Neo4j\OGM\Util\Converters\PropertyConverterFactory;
+use PHPUnit\Framework\TestCase;
+
+final class FactoryConverterTest extends TestCase
+{
+    public function testCreateDateTimeTimstampConverter(){
+        $converter = PropertyConverterFactory::getConverter("datetime");
+        $this->assertInstanceOf(DateTimeTimestampConverter::class,$converter);
+    }
+
+    public function testCreateUnexistingConverter(){
+        $converter = PropertyConverterFactory::getConverter("unknown");
+        $this->assertTrue($converter == null);
+    }
+}


### PR DESCRIPTION
Hello !
Here is a suggestion for the implementation of DateTime (in reference with #117 ) as a type of an entity property.
As you can see I create a converter which convert the DateTime object to a timestamp when the flush operation is called. When we need to hydrate an entity, the timestamp from the database is converted to DateTime with the same converter. 
This implementation use a ConverterFactory which allow future additional converters.
Now you can use DateTime object as a property type in your entity and some validators like GreaterThan and LessThan.  

```
/**
* @var DateTime
* @OGM\Property(type="datetime")
* @Assert\LessThan("-10 years", message="user.dateofbirth.tooyoung")
* @Assert\GreaterThan("-80 years", message="user.dateofbirth.tooold")
*/
private $dateOfBirth;
```

I already include simple unit TestCase’s. 
What do you think about it? 
