### PR TITLE
Remove ClientInterface declaration in EntityManager.php

### DIFF
--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -88,7 +88,7 @@ class EntityManager implements EntityManagerInterface
     protected $entityPersisters = [];
 
     public function __construct(
-        ClientInterface $databaseDriver,
+        $databaseDriver,
         $cacheDirectory = null,
         EventManager $eventManager = null,
         GraphEntityMetadataFactoryInterface $metadataFactory = null


### PR DESCRIPTION
Fixing a bug: Throws an exception when running on php7:

Argument 1 passed to GraphAware\Neo4j\OGM\EntityManager::__construct()
must be an instance of GraphAware\Neo4j\Client\ClientInterface,
instance of GraphAware\Neo4j\Client\Client given