### PR TITLE
Re-add the initial entity state reference after hydrating

### DIFF
--- a/src/Hydrator/EntityHydrator.php
+++ b/src/Hydrator/EntityHydrator.php
@@ -243,6 +243,7 @@ class EntityHydrator
                 $entity = $this->_em->getUnitOfWork()->createEntity($node, $entityName, $id);
                 $this->hydrateProperties($entity, $node);
                 $this->hydrateLabels($entity, $node);
+                $this->_em->getUnitOfWork()->addManaged($entity);
 
                 $result[] = $entity;
             }


### PR DESCRIPTION
Problem: (symfony ogm implementation)
```
$em   = $this->get('neo4j.entity_manager.default');
$node = $em->find(Node::class, 1);

$em->persist($node);
$em->flush();
```
You'd expect this code to not persist anything to neo4j as nothing is changed.
Yet when you check the UOW, it has 1 node scheduled for update.

Root cause:
Nodes are being hydrated into entities with only having their id set.
The UOW then clones this entity to keep a snapshot of the initial state (just an id at this point).
After this, the hydrator sets properties & labels on the entity, which aren't stored on the managed entity of the UOW (hence its a clone).

So if you persist the hydrated entity, the UOW compares this to the original state (just an entity with an id, nothing else), so it always gets flagged as updated.

Solution:
Re-add the entity to the UOW managed collection after the properties/labels get hydrated onto it.
`$this->_em->getUnitOfWork()->addManaged($entity);`