### PR TITLE
WIP: ProxyManager use locking when reading auto generated files

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -129,10 +129,15 @@ class $proxyClass extends $class implements EntityProxy
 PROXY;
 
         $this->checkProxyDirectory();
-        file_put_contents($proxyFile, $content);
+        file_put_contents($proxyFile, $content, LOCK_EX);
 
         if (!class_exists($proxyClass)) {
+            // using locks to avoid reading a partially written file
+            $fo = fopen($proxyFile, 'r');
+            flock($fo, LOCK_SH);
             require $proxyFile;
+            flock($fo, LOCK_UN);
+            fclose($fo);
         }
 
         return $this->newProxyInstance($proxyClass);
@@ -197,7 +202,7 @@ METHOD;
         if (!array_key_exists($proxyClass, $prototypes)) {
             $rc = @unserialize(sprintf('C:%d:"%s":0:{}', strlen($proxyClass), $proxyClass));
 
-            if (false === $rc) {
+            if (false === $rc || $rc instanceof \__PHP_Incomplete_Class) {
                 $rc = new \ReflectionClass($proxyClass);
                 return $rc->newInstanceWithoutConstructor();
             }


### PR DESCRIPTION
fixes https://github.com/graphaware/neo4j-php-ogm/issues/122

note that this should probably be improved further by skipping the file_put_contents when the file does not need to be created/updated, as discussed in https://github.com/graphaware/neo4j-php-ogm/issues/122#issuecomment-350867568