### PR TITLE
Don't persist uninitialized lazy loaded collections

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -492,7 +492,8 @@ class UnitOfWork
         $classMetadata = $this->entityManager->getClassMetadataFor(get_class($entity));
         foreach ($classMetadata->getRelationshipEntities() as $relationshipMetadata) {
             $value = $relationshipMetadata->getValue($entity);
-            if (null === $value || ($relationshipMetadata->isCollection() && count($value) === 0)) {
+            $notInitialized = $value instanceof AbstractLazyCollection && !$value->isInitialized();
+            if (null === $value || ($relationshipMetadata->isCollection() && count($value) === 0) || $notInitialized) {
                 continue;
             }
             if ($relationshipMetadata->isCollection()) {


### PR DESCRIPTION
If you have entity A with 100 relations and then you update one of the relations. Currently we are persisting all entities found over relations. And we do this recursively. 

This PR make sure not to persist relations never loaded. 